### PR TITLE
Remove Matplotlib agg backend

### DIFF
--- a/yolort/v5/utils/plots.py
+++ b/yolort/v5/utils/plots.py
@@ -37,7 +37,6 @@ from .metrics import fitness
 CONFIG_DIR = user_config_dir()  # Ultralytics settings dir
 RANK = int(os.getenv("RANK", -1))
 matplotlib.rc("font", **{"size": 11})
-matplotlib.use("Agg")  # for writing to files only
 
 
 class Colors:
@@ -446,7 +445,6 @@ def plot_labels(labels, names=(), save_dir=Path("")):
             ax[a].spines[s].set_visible(False)
 
     plt.savefig(save_dir / "labels.jpg", dpi=200)
-    matplotlib.use("Agg")
     plt.close()
 
 

--- a/yolort/v5/utils/plots.py
+++ b/yolort/v5/utils/plots.py
@@ -36,7 +36,6 @@ from .metrics import fitness
 # Settings
 CONFIG_DIR = user_config_dir()  # Ultralytics settings dir
 RANK = int(os.getenv("RANK", -1))
-matplotlib.rc("font", **{"size": 11})
 
 
 class Colors:


### PR DESCRIPTION
Fix #467 Remove Matplotlib agg backend. See https://stackoverflow.com/questions/56656777/userwarning-matplotlib-is-currently-using-agg-which-is-a-non-gui-backend-so for more details.