### PR TITLE
Resolved Issue: Fix Exporting ONNX Model with Fixed Batch Size of 1 Using export_tensorrt_engine

### DIFF
--- a/yolort/relay/trt_graphsurgeon.py
+++ b/yolort/relay/trt_graphsurgeon.py
@@ -75,7 +75,10 @@ class YOLOTRTGraphSurgeon:
             logger.info(f"Loaded saved model from {model_path}")
 
             if input_sample is not None:
+                self.batch_size = input_sample.shape[0]
                 input_sample = input_sample.to(device=device)
+            else:
+                self.batch_size = 1
             model_path = model_path.with_suffix(".onnx")
             model.to_onnx(model_path, input_sample=input_sample, enable_dynamic=enable_dynamic)
             logger.info("PyTorch2ONNX graph created successfully")
@@ -85,7 +88,6 @@ class YOLOTRTGraphSurgeon:
 
         # Fold constants via ONNX-GS that PyTorch2ONNX may have missed
         self.graph.fold_constants()
-        self.batch_size = 1
         self.precision = precision
         self.simplify = simplify
 


### PR DESCRIPTION
### Description:

This PR resolves #508 . The fix ensures that the exported models now correctly retain the specified batch size as intended, providing improved flexibility for users working with ONNX models.

### Before Fix:

<img width="400" alt="example" src="https://github.com/zhiqwang/yolort/assets/38065710/d4015a8c-0058-4b73-9c0c-d9fa04a215ed">

### After Fix:

<img width="400" alt="example" src="https://github.com/zhiqwang/yolort/assets/38065710/97b3b492-5c1c-4518-a1e0-a0308814de4a">
